### PR TITLE
Clean the apt cache after installing packages

### DIFF
--- a/ubuntu-base-prep.sh
+++ b/ubuntu-base-prep.sh
@@ -85,6 +85,7 @@ sudo chroot ${MNTROOTFS} apt-get update
 sudo chroot ${MNTROOTFS} apt-get -y install dialog apt-utils
 sudo chroot ${MNTROOTFS} apt-get -y upgrade
 sudo chroot ${MNTROOTFS} apt-get -y install systemd systemd-sysv sysvinit-utils sudo udev rsyslog kmod util-linux sed netbase dnsutils ifupdown isc-dhcp-client isc-dhcp-common less nano vim net-tools iproute2 iputils-ping libnss-mdns iw software-properties-common ethtool dmsetup hostname iptables logrotate lsb-base lsb-release plymouth psmisc tar tcpd libsystemd-dev symlinks uuid-dev libc6-dev libncurses-dev libglib2.0-dev build-essential bridge-utils zlib1g-dev patch libpixman-1-dev libyajl-dev libfdt-dev libaio-dev git libusb-1.0-0-dev libpulse-dev libcapstone-dev libnl-route-3-dev openssh-sftp-server
+sudo chroot ${MNTROOTFS} apt-get clean
 sudo cp regenerate_ssh_host_keys.service ${MNTROOTFS}etc/systemd/system
 sudo chroot ${MNTROOTFS} systemctl enable regenerate_ssh_host_keys.service
 


### PR DESCRIPTION
No reason to store the deb files for the already installed packages in the tarball.